### PR TITLE
fix: use primary color for active input option foreground

### DIFF
--- a/src/ui/form.ts
+++ b/src/ui/form.ts
@@ -38,7 +38,7 @@ export const form = (colors: UIColors): VSCodeTokens => ({
 
   'inputOption.activeBackground': colors.background.focus,
   'inputOption.activeBorder': colors.transparent,
-  'inputOption.activeForeground': colors.foreground.default,
+  'inputOption.activeForeground': colors.primary.foreground,
   'inputOption.hoverBackground': colors.background.hover,
 
   'inputValidation.errorBackground': colors.background.elevated,


### PR DESCRIPTION
This change updates inputOption.activeForeground to use the theme's primary color. In the dark theme, the active state of input option buttons (e.g. the actions next to the Search input) wasn't visually distinct enough from the inactive state.